### PR TITLE
update to minecraft 1.19

### DIFF
--- a/Images-Common/pom.xml
+++ b/Images-Common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-Common/src/main/java/com/andavin/util/MinecraftVersion.java
+++ b/Images-Common/src/main/java/com/andavin/util/MinecraftVersion.java
@@ -141,7 +141,14 @@ public enum MinecraftVersion {
      * This is only the major version of the game while minor
      * versions can be retrieved via the {@link MinorVersion#CURRENT}.
      */
-    v1_18;
+    v1_18,
+
+    /**
+     * The representation of the Minecraft version {@code 1.19}.
+     * This is only the major version of the game while minor
+     * versions can be retrieved via the {@link MinorVersion#CURRENT}.
+     */
+    v1_19;
 
     /**
      * The current {@link MinecraftVersion} of this server.

--- a/Images-Core/pom.xml
+++ b/Images-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -124,6 +124,11 @@
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>images-v1_18_R2</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>images-v1_19_R1</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>

--- a/Images-v1_10_R1/pom.xml
+++ b/Images-v1_10_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_11_R1/pom.xml
+++ b/Images-v1_11_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_12_R1/pom.xml
+++ b/Images-v1_12_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_13_R2/pom.xml
+++ b/Images-v1_13_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_14_R1/pom.xml
+++ b/Images-v1_14_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_15_R1/pom.xml
+++ b/Images-v1_15_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_16_R2/pom.xml
+++ b/Images-v1_16_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_16_R3/pom.xml
+++ b/Images-v1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_17_R1/pom.xml
+++ b/Images-v1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_18_R2/pom.xml
+++ b/Images-v1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R1/pom.xml
+++ b/Images-v1_19_R1/pom.xml
@@ -32,9 +32,9 @@
                         </goals>
                         <id>remap-obf</id>
                         <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.18.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <srgIn>org.spigotmc:minecraft-server:1.19-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
                             <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.18.1-R0.1-SNAPSHOT:jar:remapped-mojang
+                            <remappedDependencies>org.spigotmc:spigot:1.19-R0.1-SNAPSHOT:jar:remapped-mojang
                             </remappedDependencies>
                         </configuration>
                     </execution>
@@ -47,8 +47,8 @@
                         <configuration>
                             <inputFile>${project.build.directory}/${project.artifactId}-${project.version}.jar
                             </inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.18.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.18.1-R0.1-SNAPSHOT:jar:remapped-obf
+                            <srgIn>org.spigotmc:minecraft-server:1.19-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.19-R0.1-SNAPSHOT:jar:remapped-obf
                             </remappedDependencies>
                         </configuration>
                     </execution>
@@ -57,19 +57,19 @@
         </plugins>
     </build>
 
-    <artifactId>images-v1_18_R1</artifactId>
+    <artifactId>images-v1_19_R1</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18.1-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.18.1-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <classifier>remapped-mojang</classifier>
             <scope>provided</scope>
         </dependency>

--- a/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/ActionBarUtil.java
+++ b/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/ActionBarUtil.java
@@ -23,6 +23,9 @@
  */
 package com.andavin.images.v1_19_R1;
 
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
+import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.util.UUID;
@@ -37,6 +40,7 @@ class ActionBarUtil extends com.andavin.util.ActionBarUtil {
 
     @Override
     protected void sendMessage(Player player, String message) {
-        player.sendMessage(ID, message);
+        ((CraftPlayer) player).getHandle().connection.send(
+            new ClientboundSystemChatPacket(Component.translatable(message), 2));
     }
 }

--- a/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/ActionBarUtil.java
+++ b/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/ActionBarUtil.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_19_R1;
+
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+
+/**
+ * @since September 23, 2019
+ * @author Andavin
+ */
+class ActionBarUtil extends com.andavin.util.ActionBarUtil {
+
+    private static final UUID ID = new UUID(0, 0);
+
+    @Override
+    protected void sendMessage(Player player, String message) {
+        player.sendMessage(ID, message);
+    }
+}

--- a/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/ActionBarUtil.java
+++ b/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/ActionBarUtil.java
@@ -28,15 +28,11 @@ import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
 import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
-import java.util.UUID;
-
 /**
  * @since September 23, 2019
  * @author Andavin
  */
 class ActionBarUtil extends com.andavin.util.ActionBarUtil {
-
-    private static final UUID ID = new UUID(0, 0);
 
     @Override
     protected void sendMessage(Player player, String message) {

--- a/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/MapHelper.java
+++ b/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/MapHelper.java
@@ -1,0 +1,130 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_19_R1;
+
+import com.andavin.reflect.FieldMatcher;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
+import net.minecraft.network.protocol.game.ClientboundMapItemDataPacket;
+import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket;
+import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData.MapPatch;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_19_R1.block.CraftBlock;
+import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.map.MapPalette;
+import org.bukkit.map.MapView;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.andavin.reflect.Reflection.findField;
+import static com.andavin.reflect.Reflection.getFieldValue;
+import static java.util.Collections.emptyList;
+
+/**
+ * @since September 20, 2019
+ * @author Andavin
+ */
+class MapHelper extends com.andavin.images.MapHelper {
+
+    static final int DEFAULT_STARTING_ID = 8000;
+    private static final Map<UUID, AtomicInteger> MAP_IDS = new HashMap<>(4);
+    private static final EntityDataAccessor<Integer> ROTATION = getFieldValue(
+            findField(ItemFrame.class, 1, new FieldMatcher(EntityDataAccessor.class)
+                    .require(Modifier.STATIC, Modifier.FINAL)),
+            null
+    );
+
+    @Override
+    protected MapView getWorldMap(int id) {
+        //noinspection deprecation
+        return Bukkit.getMap(id);
+    }
+
+    @Override
+    protected int nextMapId(org.bukkit.World world) {
+        return MAP_IDS.computeIfAbsent(world.getUID(), __ ->
+                new AtomicInteger(DEFAULT_STARTING_ID)).getAndIncrement();
+    }
+
+    @Override
+    protected void createMap(int frameId, int mapId, Player player, Location location,
+                             BlockFace direction, int rotation, byte[] pixels) {
+
+        ItemStack item = new ItemStack(Items.FILLED_MAP);
+        item.getOrCreateTag().putInt("map", mapId);
+
+        ItemFrame frame = new ItemFrame(((CraftWorld) player.getWorld()).getHandle(),
+                new BlockPos(location.getX(), location.getY(), location.getZ()),
+                CraftBlock.blockFaceToNotch(direction));
+        frame.setItem(item, false, false);
+        frame.setInvisible(invisible);
+        frame.setId(frameId);
+        if (rotation != 0) {
+            frame.getEntityData().set(ROTATION, rotation);
+        }
+
+        ServerGamePacketListenerImpl connection = ((CraftPlayer) player).getHandle().connection;
+        connection.send(new ClientboundAddEntityPacket(frame, frame.getDirection().get3DDataValue(), frame.getPos()));
+        connection.send(new ClientboundSetEntityDataPacket(frame.getId(), frame.getEntityData(), true));
+        connection.send(new ClientboundMapItemDataPacket(mapId, (byte) 3, false,
+                emptyList(), new MapPatch(0, 0, 128, 128, pixels)));
+    }
+
+    @Override
+    protected void destroyMap(Player player, int[] frameIds) {
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundRemoveEntitiesPacket(frameIds));
+    }
+
+    @Override
+    protected byte[] createPixels(BufferedImage image) {
+
+        int pixelCount = image.getWidth() * image.getHeight();
+        int[] pixels = new int[pixelCount];
+        image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels, 0, image.getWidth());
+
+        byte[] colors = new byte[pixelCount];
+        for (int i = 0; i < pixelCount; i++) {
+            //noinspection deprecation
+            colors[i] = MapPalette.matchColor(new Color(pixels[i], true));
+        }
+
+        return colors;
+    }
+}

--- a/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/PacketListener.java
+++ b/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/PacketListener.java
@@ -1,0 +1,146 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_19_R1;
+
+import com.andavin.images.image.CustomImageSection;
+import com.andavin.util.Logger;
+import com.andavin.util.Scheduler;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket.Handler;
+import net.minecraft.network.protocol.game.ServerboundSetCreativeModeSlotPacket;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.MapItem;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.craftbukkit.v1_19_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.andavin.reflect.Reflection.findField;
+import static com.andavin.reflect.Reflection.getFieldValue;
+
+/**
+ * @since September 21, 2019
+ * @author Andavin
+ */
+class PacketListener extends com.andavin.images.PacketListener<ServerboundInteractPacket, ServerboundSetCreativeModeSlotPacket> {
+
+    private static final Field ENTITY_ID = findField(ServerboundInteractPacket.class, "a");
+
+    @Override
+    protected void setEntityListener(Player player, ImageListener listener) {
+        ServerGamePacketListenerImpl connection = ((CraftPlayer) player).getHandle().connection;
+        connection.connection.setListener(new PlayerConnectionProxy(connection, listener, this));
+    }
+
+    @Override
+    protected void handle(Player player, ImageListener listener, ServerboundInteractPacket packet) {
+        int entityId = getFieldValue(ENTITY_ID, packet);
+        packet.dispatch(new Handler() {
+            @Override
+            public void onInteraction(InteractionHand hand) {
+                call(player, entityId, InteractType.RIGHT_CLICK,
+                        hand == InteractionHand.MAIN_HAND ? Hand.MAIN_HAND : Hand.OFF_HAND, listener);
+            }
+
+            @Override
+            public void onInteraction(InteractionHand hand, Vec3 vec3) {
+                call(player, entityId, InteractType.RIGHT_CLICK,
+                        hand == InteractionHand.MAIN_HAND ? Hand.MAIN_HAND : Hand.OFF_HAND, listener);
+            }
+
+            @Override
+            public void onAttack() {
+                call(player, entityId, InteractType.LEFT_CLICK, Hand.MAIN_HAND, listener);
+            }
+        });
+    }
+
+    @Override
+    protected void handle(Player player, ServerboundSetCreativeModeSlotPacket packet) {
+
+        ItemStack item = packet.getItem();
+        CompoundTag tag = item.getTag();
+        if (tag != null) {
+
+            int mapId = tag.getInt("map");
+            if (mapId >= MapHelper.DEFAULT_STARTING_ID) {
+
+                CustomImageSection section = getImageSection(mapId);
+                if (section != null) {
+
+                    AtomicBoolean complete = new AtomicBoolean();
+                    Scheduler.sync(() -> {
+
+                        try {
+
+                            ServerLevel world = ((CraftPlayer) player).getHandle().getLevel();
+                            MapItemSavedData map = MapItem.getSavedData(mapId, world);
+                            if (map == null) {
+                                ItemStack newItem = MapItem.create(world, 0, 0, (byte) 3, false, false);
+                                int newMapId = newItem.getOrCreateTag().getInt("map");
+                                tag.putInt("map", newMapId); // Transfer the ID
+                                map = MapItem.getSavedData(newMapId, world);
+                            }
+
+                            if (map != null) {
+                                map.locked = true;
+                                map.scale = 3;
+                                map.trackingPosition = false;
+                                map.unlimitedTracking = true;
+                                map.colors = section.getPixels();
+                            } else {
+                                player.sendMessage("§cCannot create map. Unknown map data...");
+                            }
+                        } finally {
+
+                            complete.set(true);
+                            synchronized (complete) {
+                                complete.notify();
+                            }
+                        }
+                    });
+
+                    synchronized (complete) {
+
+                        while (!complete.get()) {
+
+                            try {
+                                complete.wait();
+                            } catch (InterruptedException e) {
+                                Logger.severe(e);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/PlayerConnectionProxy.java
+++ b/Images-v1_19_R1/src/main/java/com/andavin/images/v1_19_R1/PlayerConnectionProxy.java
@@ -1,0 +1,66 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_19_R1;
+
+import com.andavin.images.PacketListener.ImageListener;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundSetCreativeModeSlotPacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_19_R1.CraftServer;
+
+/**
+ * @since September 21, 2019
+ * @author Andavin
+ */
+public class PlayerConnectionProxy extends ServerGamePacketListenerImpl {
+
+    private final ImageListener listener;
+    private final PacketListener packetListener;
+
+    PlayerConnectionProxy(ServerGamePacketListenerImpl connection,
+                          ImageListener listener, PacketListener packetListener) {
+        super(((CraftServer) Bukkit.getServer()).getServer(), connection.connection, connection.player);
+        this.listener = listener;
+        this.packetListener = packetListener;
+    }
+
+    @Override
+    public void send(Packet<?> packet) {
+        super.send(packet);
+    }
+
+    @Override
+    public void handleInteract(ServerboundInteractPacket packet) {
+        packetListener.handle(player.getBukkitEntity(), listener, packet);
+        super.handleInteract(packet);
+    }
+
+    @Override
+    public void handleSetCreativeModeSlot(ServerboundSetCreativeModeSlotPacket packet) {
+        packetListener.handle(player.getBukkitEntity(), packet);
+        super.handleSetCreativeModeSlot(packet);
+    }
+}

--- a/Images-v1_8_R3/pom.xml
+++ b/Images-v1_8_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_9_R2/pom.xml
+++ b/Images-v1_9_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ Compiling
 2. Compile from the parent project of Images that all modules are contained within
 3. Run `mvn clean package`
 
+Compiling Dependencies
+---------
+
+You might see maven builds fail due to missing dependencies on, e.g. spigot-api-1.19-R0.1. 
+These dependencies are not available on maven central, and as such you will need to build and install them 
+in your local maven repository. To do this follow these steps.
+
+1. Download the spigotmc BuildTools.jar from https://hub.spigotmc.org/jenkins/job/BuildTools/.
+2. Familiarize yourself with https://www.spigotmc.org/wiki/buildtools/.
+3. Run `java -jar BuildTools.jar --compile SPIGOT --remapped -rev 1.19` from inside the foler where you palced BuildTools.jar
+4. Adapt rev to any version you need the dependency for.
+
+You might have to switch Java installations in between as different spigot versions rely on different Java versions.
+
 Contributing
 ------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.andavin</groupId>
     <artifactId>images-parent</artifactId>
-    <version>2.2.5</version>
+    <version>2.2.6</version>
     <modules>
         <module>Images-Core</module>
         <module>Images-Common</module>
@@ -23,6 +23,7 @@
         <module>Images-v1_17_R1</module>
         <module>Images-v1_18_R1</module>
         <module>Images-v1_18_R2</module>
+        <module>Images-v1_19_R1</module>
     </modules>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Updated to work with Minecraft 1.19

    bumped version to 2.2.6
    adapted dependencies to target new spigot release
    TextComponent and ClientboundChatPacket don't exist anymore, code now just uses sendMessage method
    ClientboundAddEntityPacket changed available parameters, now omitting EntityType.ITEM_FRAME
    Added explanation on how to build dependencies to README.md, as those came up in the last pull request


I just tried to get this up and running for our server quickly and it seems to work, however the message prompt to place the image is now being sent multiple times. Not sure on how to fix it, open to any input!
