### PR TITLE
Allow custom render/hide distances

### DIFF
--- a/Images-Common/src/main/java/com/andavin/images/MapHelper.java
+++ b/Images-Common/src/main/java/com/andavin/images/MapHelper.java
@@ -38,6 +38,8 @@ import java.awt.image.BufferedImage;
 public abstract class MapHelper implements Versioned {
 
     protected static boolean invisible = true;
+    public static int showDistance = 64;
+    public static int hideDistance = 128;
     private static final MapHelper BRIDGE = Versioned.getInstance(MapHelper.class);
 
     /**

--- a/Images-Common/src/main/java/com/andavin/images/image/CustomImage.java
+++ b/Images-Common/src/main/java/com/andavin/images/image/CustomImage.java
@@ -171,9 +171,9 @@ public class CustomImage implements Serializable {
             if (sameWorld) {
 
                 double distance = section.getLocation().distanceSquared(location);
-                if (distance <= 64 * 64) {
+                if (distance <= MapHelper.showDistance * MapHelper.showDistance) {
                     section.show(player);
-                } else if (distance > 128 * 128) {
+                } else if (distance > MapHelper.hideDistance * MapHelper.hideDistance) {
                     section.hide(player);
                 }
             } else {

--- a/Images-Core/src/main/java/com/andavin/images/Images.java
+++ b/Images-Core/src/main/java/com/andavin/images/Images.java
@@ -122,6 +122,8 @@ public class Images extends JavaPlugin implements Listener {
 
         FileConfiguration config = this.getConfig();
         MapHelper.invisible = config.getBoolean("invisible-frames", true);
+        MapHelper.showDistance = config.getInt("show-distance", 64);
+        MapHelper.hideDistance = config.getInt("hide-distance", 128);
         String type = config.getString("database.type").toUpperCase(Locale.ENGLISH);
         switch (type) {
             case "MYSQL":

--- a/Images-Core/src/main/resources/config.yml
+++ b/Images-Core/src/main/resources/config.yml
@@ -11,6 +11,12 @@
 # NOTE: only supported in 1.16+
 invisible-frames: true
 
+# Image sections within this range will be visible to players
+show-distance: 64
+
+# Image sections beyond this range will be hidden from players
+hide-distance: 128
+
 database:
   # The type of database that can be used
   # Options: MYSQL, SQLITE, FILE - Default: SQLITE


### PR DESCRIPTION
This change adds the ability to configure the distances for rendering and hiding images. We needed a way to make some images visible at a greater player distance, so I've added a way to configure the distances instead of the hardcoded ones.

Fairly simple change and has been in use on our own servers for a while, finally got around to submitting this back :slightly_smiling_face: 