### PR TITLE
Update to version 2.5.0 with support for 1.21 and Paper

### DIFF
--- a/Images-Common/pom.xml
+++ b/Images-Common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-Common/src/main/java/com/andavin/util/MinecraftVersion.java
+++ b/Images-Common/src/main/java/com/andavin/util/MinecraftVersion.java
@@ -155,7 +155,14 @@ public enum MinecraftVersion {
      * This is only the major version of the game while minor
      * versions can be retrieved via the {@link MinorVersion#CURRENT}.
      */
-    v1_20;
+    v1_20,
+
+    /**
+     * The representation of the Minecraft version {@code 1.21}.
+     * This is only the major version of the game while minor
+     * versions can be retrieved via the {@link MinorVersion#CURRENT}.
+     */
+    v1_21;
 
     /**
      * The current {@link MinecraftVersion} of this server.

--- a/Images-Core/pom.xml
+++ b/Images-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -159,6 +159,11 @@
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>images-v1_20_R4</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>images-v1_21_R1</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>

--- a/Images-v1_10_R1/pom.xml
+++ b/Images-v1_10_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_11_R1/pom.xml
+++ b/Images-v1_11_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_12_R1/pom.xml
+++ b/Images-v1_12_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_13_R2/pom.xml
+++ b/Images-v1_13_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_14_R1/pom.xml
+++ b/Images-v1_14_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_15_R1/pom.xml
+++ b/Images-v1_15_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_16_R2/pom.xml
+++ b/Images-v1_16_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_16_R3/pom.xml
+++ b/Images-v1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_17_R1/pom.xml
+++ b/Images-v1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_18_R1/pom.xml
+++ b/Images-v1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_18_R2/pom.xml
+++ b/Images-v1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R1/pom.xml
+++ b/Images-v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R2/pom.xml
+++ b/Images-v1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R3/pom.xml
+++ b/Images-v1_19_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R1/pom.xml
+++ b/Images-v1_20_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R2/pom.xml
+++ b/Images-v1_20_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R3/pom.xml
+++ b/Images-v1_20_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R4/pom.xml
+++ b/Images-v1_20_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R1/pom.xml
+++ b/Images-v1_21_R1/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>images-parent</artifactId>
+        <groupId>com.andavin</groupId>
+        <version>2.5.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.md-5</groupId>
+                <artifactId>specialsource-maven-plugin</artifactId>
+                <version>2.0.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>remap</goal>
+                        </goals>
+                        <id>remap-obf</id>
+                        <configuration>
+                            <srgIn>org.spigotmc:minecraft-server:1.21-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <reverse>true</reverse>
+                            <remappedDependencies>org.spigotmc:spigot:1.21-R0.1-SNAPSHOT:jar:remapped-mojang
+                            </remappedDependencies>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>remap</goal>
+                        </goals>
+                        <id>remap-spigot</id>
+                        <configuration>
+                            <inputFile>${project.build.directory}/${project.artifactId}-${project.version}.jar
+                            </inputFile>
+                            <srgIn>org.spigotmc:minecraft-server:1.21-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.21-R0.1-SNAPSHOT:jar:remapped-obf
+                            </remappedDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <artifactId>images-v1_21_R1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <classifier>remapped-mojang</classifier>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>images-common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/Images-v1_21_R1/src/main/java/com/andavin/images/v1_21_R1/ActionBarUtil.java
+++ b/Images-v1_21_R1/src/main/java/com/andavin/images/v1_21_R1/ActionBarUtil.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_21_R1;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundSetActionBarTextPacket;
+import org.bukkit.craftbukkit.v1_21_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @since September 23, 2019
+ * @author Andavin
+ */
+class ActionBarUtil extends com.andavin.util.ActionBarUtil {
+
+    @Override
+    protected void sendMessage(Player player, String message) {
+        ((CraftPlayer) player).getHandle().connection.send(
+                new ClientboundSetActionBarTextPacket(Component.literal(message)));
+    }
+}

--- a/Images-v1_21_R1/src/main/java/com/andavin/images/v1_21_R1/MapHelper.java
+++ b/Images-v1_21_R1/src/main/java/com/andavin/images/v1_21_R1/MapHelper.java
@@ -1,0 +1,133 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_21_R1;
+
+import com.andavin.reflect.FieldMatcher;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
+import net.minecraft.network.protocol.game.ClientboundMapItemDataPacket;
+import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket;
+import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.saveddata.maps.MapId;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData.MapPatch;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+import org.bukkit.craftbukkit.v1_21_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R1.block.CraftBlock;
+import org.bukkit.craftbukkit.v1_21_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.map.MapPalette;
+import org.bukkit.map.MapView;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.andavin.reflect.Reflection.findField;
+import static com.andavin.reflect.Reflection.getFieldValue;
+import static java.util.Collections.emptyList;
+
+/**
+ * @since September 20, 2019
+ * @author Andavin
+ */
+class MapHelper extends com.andavin.images.MapHelper {
+
+    static final int DEFAULT_STARTING_ID = 1_000_000;
+    private static final Map<UUID, AtomicInteger> MAP_IDS = new HashMap<>(4);
+    private static final EntityDataAccessor<Integer> ROTATION = getFieldValue(
+            findField(ItemFrame.class, 1, new FieldMatcher(EntityDataAccessor.class)
+                    .require(Modifier.STATIC, Modifier.FINAL)),
+            null
+    );
+
+    @Override
+    protected MapView getWorldMap(int id) {
+        //noinspection deprecation
+        return Bukkit.getMap(id);
+    }
+
+    @Override
+    protected int nextMapId(org.bukkit.World world) {
+        return MAP_IDS.computeIfAbsent(world.getUID(), __ ->
+                new AtomicInteger(DEFAULT_STARTING_ID)).getAndIncrement();
+    }
+
+    @Override
+    protected void createMap(int frameId, int mapId, Player player, Location location,
+                             BlockFace direction, int rotation, byte[] pixels) {
+
+        MapId mapIdObj = new MapId(mapId);
+        ItemStack item = new ItemStack(Items.FILLED_MAP);
+        item.set(DataComponents.MAP_ID, mapIdObj);
+
+        ItemFrame frame = new ItemFrame(((CraftWorld) player.getWorld()).getHandle(),
+                BlockPos.containing(location.getX(), location.getY(), location.getZ()),
+                CraftBlock.blockFaceToNotch(direction));
+        frame.setItem(item, false, false);
+        frame.setInvisible(invisible);
+        frame.setId(frameId);
+        if (rotation != 0) {
+            frame.getEntityData().set(ROTATION, rotation);
+        }
+
+        ServerGamePacketListenerImpl connection = ((CraftPlayer) player).getHandle().connection;
+        connection.send(new ClientboundAddEntityPacket(frame, frame.getDirection().get3DDataValue(), frame.getPos()));
+        connection.send(new ClientboundSetEntityDataPacket(frame.getId(), frame.getEntityData().packDirty()));
+        connection.send(new ClientboundMapItemDataPacket(mapIdObj, (byte) 3, false,
+                emptyList(), new MapPatch(0, 0, 128, 128, pixels)));
+    }
+
+    @Override
+    protected void destroyMap(Player player, int[] frameIds) {
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundRemoveEntitiesPacket(frameIds));
+    }
+
+    @Override
+    protected byte[] createPixels(BufferedImage image) {
+
+        int pixelCount = image.getWidth() * image.getHeight();
+        int[] pixels = new int[pixelCount];
+        image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels, 0, image.getWidth());
+
+        byte[] colors = new byte[pixelCount];
+        for (int i = 0; i < pixelCount; i++) {
+            //noinspection deprecation
+            colors[i] = MapPalette.matchColor(new Color(pixels[i], true));
+        }
+
+        return colors;
+    }
+}

--- a/Images-v1_21_R1/src/main/java/com/andavin/images/v1_21_R1/PacketListener.java
+++ b/Images-v1_21_R1/src/main/java/com/andavin/images/v1_21_R1/PacketListener.java
@@ -1,0 +1,152 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_21_R1;
+
+import com.andavin.images.image.CustomImageSection;
+import com.andavin.reflect.FieldMatcher;
+import com.andavin.util.Logger;
+import com.andavin.util.Scheduler;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket.Handler;
+import net.minecraft.network.protocol.game.ServerboundSetCreativeModeSlotPacket;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.network.CommonListenerCookie;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.MapItem;
+import net.minecraft.world.level.saveddata.maps.MapId;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.craftbukkit.v1_21_R1.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.andavin.reflect.Reflection.*;
+
+/**
+ * @since March 19, 2023
+ * @author Andavin
+ */
+class PacketListener extends com.andavin.images.PacketListener<ServerboundInteractPacket, ServerboundSetCreativeModeSlotPacket> {
+
+    private static final Field ENTITY_ID = findField(ServerboundInteractPacket.class, new FieldMatcher(int.class));
+    private static final Field CONNECTION = findField(ServerCommonPacketListenerImpl.class, new FieldMatcher(Connection.class));
+    private static final Field LISTENER = findField(Connection.class, 1, new FieldMatcher(net.minecraft.network.PacketListener.class));
+
+    @Override
+    protected void setEntityListener(Player player, ImageListener listener) {
+        ServerGamePacketListenerImpl connection = ((CraftPlayer) player).getHandle().connection;
+        Connection internal = getFieldValue(CONNECTION, connection);
+        setFieldValue(LISTENER, internal, new PlayerConnectionProxy(
+                connection, internal, listener,
+                this, new CommonListenerCookie(null, 0, null, false)
+        ));
+    }
+
+    @Override
+    protected void handle(Player player, ImageListener listener, ServerboundInteractPacket packet) {
+        int entityId = getFieldValue(ENTITY_ID, packet);
+        packet.dispatch(new Handler() {
+            @Override
+            public void onInteraction(InteractionHand hand) {
+                call(player, entityId, InteractType.RIGHT_CLICK,
+                        hand == InteractionHand.MAIN_HAND ? Hand.MAIN_HAND : Hand.OFF_HAND, listener);
+            }
+
+            @Override
+            public void onInteraction(InteractionHand hand, Vec3 vec3) {
+                call(player, entityId, InteractType.RIGHT_CLICK,
+                        hand == InteractionHand.MAIN_HAND ? Hand.MAIN_HAND : Hand.OFF_HAND, listener);
+            }
+
+            @Override
+            public void onAttack() {
+                call(player, entityId, InteractType.LEFT_CLICK, Hand.MAIN_HAND, listener);
+            }
+        });
+    }
+
+    @Override
+    protected void handle(Player player, ServerboundSetCreativeModeSlotPacket packet) {
+
+        ItemStack item = packet.itemStack();
+        MapId mapId = item.get(DataComponents.MAP_ID);
+        if (mapId != null && mapId.id() >= MapHelper.DEFAULT_STARTING_ID) {
+
+            CustomImageSection section = getImageSection(mapId.id());
+            if (section != null) {
+
+                AtomicBoolean complete = new AtomicBoolean();
+                Scheduler.sync(() -> {
+
+                    try {
+
+                        ServerLevel world = ((CraftPlayer) player).getHandle().serverLevel();
+                        MapItemSavedData map = MapItem.getSavedData(mapId, world);
+                        if (map == null) {
+                            ItemStack newItem = MapItem.create(world, 0, 0, (byte) 3, false, false);
+                            MapId newMapId = newItem.get(DataComponents.MAP_ID);
+                            item.set(DataComponents.MAP_ID, newMapId); // Transfer the ID
+                            map = MapItem.getSavedData(newMapId, world);
+                        }
+
+                        if (map != null) {
+                            map.locked = true;
+                            map.scale = 3;
+                            map.trackingPosition = false;
+                            map.unlimitedTracking = true;
+                            map.colors = section.getPixels();
+                        } else {
+                            player.sendMessage("§cCannot create map. Unknown map data...");
+                        }
+                    } finally {
+
+                        complete.set(true);
+                        synchronized (complete) {
+                            complete.notify();
+                        }
+                    }
+                });
+
+                synchronized (complete) {
+
+                    while (!complete.get()) {
+
+                        try {
+                            complete.wait();
+                        } catch (InterruptedException e) {
+                            Logger.severe(e);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Images-v1_21_R1/src/main/java/com/andavin/images/v1_21_R1/PlayerConnectionProxy.java
+++ b/Images-v1_21_R1/src/main/java/com/andavin/images/v1_21_R1/PlayerConnectionProxy.java
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_21_R1;
+
+import com.andavin.images.PacketListener.ImageListener;
+import com.andavin.reflect.FieldMatcher;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundSetCreativeModeSlotPacket;
+import net.minecraft.server.network.CommonListenerCookie;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_21_R1.CraftServer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static com.andavin.reflect.Reflection.*;
+
+/**
+ * @since March 19, 2023
+ * @author Andavin
+ */
+public class PlayerConnectionProxy extends ServerGamePacketListenerImpl {
+
+    private static final Field AWAITING_TELEPORT = findField(ServerGamePacketListenerImpl.class, 3,
+            new FieldMatcher(int.class).disallow(Modifier.STATIC));
+    private static final Field AWAITING_POSITION_FROM_CLIENT = findField(ServerGamePacketListenerImpl.class,
+            new FieldMatcher(Vec3.class));
+    private final ImageListener listener;
+    private final PacketListener packetListener;
+
+    PlayerConnectionProxy(ServerGamePacketListenerImpl connection, Connection internal,
+                          ImageListener listener, PacketListener packetListener,
+                          CommonListenerCookie cookie) {
+        super(((CraftServer) Bukkit.getServer()).getServer(), internal, connection.player, cookie);
+        this.listener = listener;
+        this.packetListener = packetListener;
+        setFieldValue(AWAITING_TELEPORT, this, getFieldValue(AWAITING_TELEPORT, connection));
+        setFieldValue(AWAITING_POSITION_FROM_CLIENT, this, getFieldValue(AWAITING_POSITION_FROM_CLIENT, connection));
+    }
+
+    @Override
+    public void send(Packet<?> packet) {
+        super.send(packet);
+    }
+
+    @Override
+    public void handleInteract(ServerboundInteractPacket packet) {
+        packetListener.handle(player.getBukkitEntity(), listener, packet);
+        super.handleInteract(packet);
+    }
+
+    @Override
+    public void handleSetCreativeModeSlot(ServerboundSetCreativeModeSlotPacket packet) {
+        packetListener.handle(player.getBukkitEntity(), packet);
+        super.handleSetCreativeModeSlot(packet);
+    }
+}

--- a/Images-v1_8_R3/pom.xml
+++ b/Images-v1_8_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_9_R2/pom.xml
+++ b/Images-v1_9_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.4.0</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.andavin</groupId>
     <artifactId>images-parent</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
     <modules>
         <module>Images-Core</module>
         <module>Images-Common</module>
@@ -30,6 +30,7 @@
         <module>Images-v1_20_R2</module>
         <module>Images-v1_20_R3</module>
         <module>Images-v1_20_R4</module>
+        <module>Images-v1_21_R1</module>
     </modules>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
This adds support for Spigot 1.21 along with tentative support for Paper. 

When using Paper you may run into issues such as not deleting images, slow rendering etc. If you have an issue with deleting images, use the `/image delete near <distance>` command for alternative delete methods.

P.S. I intend on releasing a full Paper version of this plugin at some point, but it will likely be a while.