### PR TITLE
Support for 1.21.6

### DIFF
--- a/Images-Common/pom.xml
+++ b/Images-Common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-Common/src/main/java/com/andavin/util/MinecraftVersion.java
+++ b/Images-Common/src/main/java/com/andavin/util/MinecraftVersion.java
@@ -419,6 +419,8 @@ public enum MinecraftVersion {
                 case "1.20.6":
                 case "1.21.5":
                     return "R4";
+                case "1.21.6":
+                    return "R5";
                 default:
                     // NOTE: for future compatibility, we will default to the last version minor version
                     // This will definitely have issues on certain versions, but it will save others

--- a/Images-Core/pom.xml
+++ b/Images-Core/pom.xml
@@ -181,6 +181,11 @@
             <artifactId>images-v1_21_R4</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>images-v1_21_R5</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/Images-Core/pom.xml
+++ b/Images-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_10_R1/pom.xml
+++ b/Images-v1_10_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_11_R1/pom.xml
+++ b/Images-v1_11_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_12_R1/pom.xml
+++ b/Images-v1_12_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_13_R2/pom.xml
+++ b/Images-v1_13_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_14_R1/pom.xml
+++ b/Images-v1_14_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_15_R1/pom.xml
+++ b/Images-v1_15_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_16_R2/pom.xml
+++ b/Images-v1_16_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_16_R3/pom.xml
+++ b/Images-v1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_17_R1/pom.xml
+++ b/Images-v1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_18_R1/pom.xml
+++ b/Images-v1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_18_R2/pom.xml
+++ b/Images-v1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R1/pom.xml
+++ b/Images-v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R2/pom.xml
+++ b/Images-v1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R3/pom.xml
+++ b/Images-v1_19_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R1/pom.xml
+++ b/Images-v1_20_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R2/pom.xml
+++ b/Images-v1_20_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R3/pom.xml
+++ b/Images-v1_20_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R4/pom.xml
+++ b/Images-v1_20_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R1/pom.xml
+++ b/Images-v1_21_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R2/pom.xml
+++ b/Images-v1_21_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R3/pom.xml
+++ b/Images-v1_21_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R4/pom.xml
+++ b/Images-v1_21_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R5/pom.xml
+++ b/Images-v1_21_R5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R5/pom.xml
+++ b/Images-v1_21_R5/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>images-parent</artifactId>
+        <groupId>com.andavin</groupId>
+        <version>2.5.5</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.md-5</groupId>
+                <artifactId>specialsource-maven-plugin</artifactId>
+                <version>2.0.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>remap</goal>
+                        </goals>
+                        <id>remap-obf</id>
+                        <configuration>
+                            <srgIn>org.spigotmc:minecraft-server:1.21.6-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <reverse>true</reverse>
+                            <remappedDependencies>org.spigotmc:spigot:1.21.6-R0.1-SNAPSHOT:jar:remapped-mojang
+                            </remappedDependencies>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>remap</goal>
+                        </goals>
+                        <id>remap-spigot</id>
+                        <configuration>
+                            <inputFile>${project.build.directory}/${project.artifactId}-${project.version}.jar
+                            </inputFile>
+                            <srgIn>org.spigotmc:minecraft-server:1.21.6-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.21.6-R0.1-SNAPSHOT:jar:remapped-obf
+                            </remappedDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <artifactId>images-v1_21_R5</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.21.6-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.21.6-R0.1-SNAPSHOT</version>
+            <classifier>remapped-mojang</classifier>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>images-common</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/Images-v1_21_R5/src/main/java/com/andavin/images/v1_21_R5/ActionBarUtil.java
+++ b/Images-v1_21_R5/src/main/java/com/andavin/images/v1_21_R5/ActionBarUtil.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_21_R5;
+
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundSetActionBarTextPacket;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * @since September 23, 2019
+ * @author Andavin
+ */
+class ActionBarUtil extends com.andavin.util.ActionBarUtil {
+
+    @Override
+    protected void sendMessage(Player player, String message) {
+        ((CraftPlayer) player).getHandle().connection.send(
+                new ClientboundSetActionBarTextPacket(Component.literal(message)));
+    }
+}

--- a/Images-v1_21_R5/src/main/java/com/andavin/images/v1_21_R5/MapHelper.java
+++ b/Images-v1_21_R5/src/main/java/com/andavin/images/v1_21_R5/MapHelper.java
@@ -1,0 +1,133 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_21_R5;
+
+import com.andavin.reflect.FieldMatcher;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
+import net.minecraft.network.protocol.game.ClientboundMapItemDataPacket;
+import net.minecraft.network.protocol.game.ClientboundRemoveEntitiesPacket;
+import net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.entity.decoration.ItemFrame;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.saveddata.maps.MapId;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData.MapPatch;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+import org.bukkit.craftbukkit.v1_21_R5.CraftWorld;
+import org.bukkit.craftbukkit.v1_21_R5.block.CraftBlock;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.map.MapPalette;
+import org.bukkit.map.MapView;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.andavin.reflect.Reflection.findField;
+import static com.andavin.reflect.Reflection.getFieldValue;
+import static java.util.Collections.emptyList;
+
+/**
+ * @since September 20, 2019
+ * @author Andavin
+ */
+class MapHelper extends com.andavin.images.MapHelper {
+
+    static final int DEFAULT_STARTING_ID = 1_000_000;
+    private static final Map<UUID, AtomicInteger> MAP_IDS = new HashMap<>(4);
+    private static final EntityDataAccessor<Integer> ROTATION = getFieldValue(
+            findField(ItemFrame.class, 1, new FieldMatcher(EntityDataAccessor.class)
+                    .require(Modifier.STATIC, Modifier.FINAL)),
+            null
+    );
+
+    @Override
+    protected MapView getWorldMap(int id) {
+        //noinspection deprecation
+        return Bukkit.getMap(id);
+    }
+
+    @Override
+    protected int nextMapId(org.bukkit.World world) {
+        return MAP_IDS.computeIfAbsent(world.getUID(), __ ->
+                new AtomicInteger(DEFAULT_STARTING_ID)).getAndIncrement();
+    }
+
+    @Override
+    protected void createMap(int frameId, int mapId, Player player, Location location,
+                             BlockFace direction, int rotation, byte[] pixels) {
+
+        MapId mapIdObj = new MapId(mapId);
+        ItemStack item = new ItemStack(Items.FILLED_MAP);
+        item.set(DataComponents.MAP_ID, mapIdObj);
+
+        ItemFrame frame = new ItemFrame(((CraftWorld) player.getWorld()).getHandle(),
+                BlockPos.containing(location.getX(), location.getY(), location.getZ()),
+                CraftBlock.blockFaceToNotch(direction));
+        frame.setItem(item, false, false);
+        frame.setInvisible(invisible);
+        frame.setId(frameId);
+        if (rotation != 0) {
+            frame.getEntityData().set(ROTATION, rotation);
+        }
+
+        ServerGamePacketListenerImpl connection = ((CraftPlayer) player).getHandle().connection;
+        connection.send(new ClientboundAddEntityPacket(frame, frame.getDirection().get3DDataValue(), frame.getPos()));
+        connection.send(new ClientboundSetEntityDataPacket(frame.getId(), frame.getEntityData().packDirty()));
+        connection.send(new ClientboundMapItemDataPacket(mapIdObj, (byte) 3, false,
+                emptyList(), new MapPatch(0, 0, 128, 128, pixels)));
+    }
+
+    @Override
+    protected void destroyMap(Player player, int[] frameIds) {
+        ((CraftPlayer) player).getHandle().connection.send(new ClientboundRemoveEntitiesPacket(frameIds));
+    }
+
+    @Override
+    protected byte[] createPixels(BufferedImage image) {
+
+        int pixelCount = image.getWidth() * image.getHeight();
+        int[] pixels = new int[pixelCount];
+        image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels, 0, image.getWidth());
+
+        byte[] colors = new byte[pixelCount];
+        for (int i = 0; i < pixelCount; i++) {
+            //noinspection deprecation
+            colors[i] = MapPalette.matchColor(new Color(pixels[i], true));
+        }
+
+        return colors;
+    }
+}

--- a/Images-v1_21_R5/src/main/java/com/andavin/images/v1_21_R5/PacketListener.java
+++ b/Images-v1_21_R5/src/main/java/com/andavin/images/v1_21_R5/PacketListener.java
@@ -1,0 +1,149 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_21_R5;
+
+import com.andavin.images.image.CustomImageSection;
+import com.andavin.reflect.FieldMatcher;
+import com.andavin.reflect.MethodMatcher;
+import com.andavin.reflect.exception.UncheckedNoSuchMethodException;
+import com.andavin.util.Scheduler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket.Handler;
+import net.minecraft.network.protocol.game.ServerboundPickItemFromEntityPacket;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.network.ServerCommonPacketListenerImpl;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.MapItem;
+import net.minecraft.world.level.saveddata.maps.MapId;
+import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
+import net.minecraft.world.phys.Vec3;
+import org.bukkit.craftbukkit.v1_21_R5.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static com.andavin.reflect.Reflection.*;
+
+/**
+ * @since March 19, 2023
+ * @author Andavin
+ */
+class PacketListener extends com.andavin.images.PacketListener<ServerboundInteractPacket, ServerboundPickItemFromEntityPacket> {
+
+    private static final Method TRY_PICK_ITEM;
+    private static final Field ENTITY_ID = findField(ServerboundInteractPacket.class, new FieldMatcher(int.class));
+    private static final Field CONNECTION = findField(ServerCommonPacketListenerImpl.class, new FieldMatcher(Connection.class));
+
+    static {
+        Method tryPickItem = null;
+        try {
+            tryPickItem = findMethod(ServerGamePacketListenerImpl.class,
+                    new MethodMatcher(void.class, ItemStack.class));
+        } catch (UncheckedNoSuchMethodException e) { // Paper modifies the tryPickItem method in 1.21.5
+            tryPickItem = findMethod(ServerGamePacketListenerImpl.class,
+                    new MethodMatcher(void.class, ItemStack.class, BlockPos.class, Entity.class, boolean.class));
+        } finally {
+            TRY_PICK_ITEM = tryPickItem;
+        }
+    }
+
+    @Override
+    protected void setEntityListener(Player player, ImageListener listener) {
+        ServerGamePacketListenerImpl connection = ((CraftPlayer) player).getHandle().connection;
+        Connection internal = getFieldValue(CONNECTION, connection);
+        internal.channel.pipeline().addBefore("packet_handler", "image_handler",
+                new PlayerConnectionProxy(connection, listener, this));
+    }
+
+    @Override
+    protected void handle(Player player, ImageListener listener, ServerboundInteractPacket packet) {
+        int entityId = getFieldValue(ENTITY_ID, packet);
+        packet.dispatch(new Handler() {
+            @Override
+            public void onInteraction(InteractionHand hand) {
+                call(player, entityId, InteractType.RIGHT_CLICK,
+                        hand == InteractionHand.MAIN_HAND ? Hand.MAIN_HAND : Hand.OFF_HAND, listener);
+            }
+
+            @Override
+            public void onInteraction(InteractionHand hand, Vec3 vec3) {
+                call(player, entityId, InteractType.RIGHT_CLICK,
+                        hand == InteractionHand.MAIN_HAND ? Hand.MAIN_HAND : Hand.OFF_HAND, listener);
+            }
+
+            @Override
+            public void onAttack() {
+                call(player, entityId, InteractType.LEFT_CLICK, Hand.MAIN_HAND, listener);
+            }
+        });
+    }
+
+    @Override
+    protected void handle(Player player, ServerboundPickItemFromEntityPacket packet) {
+
+        CustomImageSection section = getImageSectionByEntityId(packet.id());
+        if (section == null) {
+            return;
+        }
+
+        MapId mapId = new MapId(section.getMapId());
+        ItemStack item = new ItemStack(Items.FILLED_MAP);
+        item.set(DataComponents.MAP_ID, mapId);
+        Scheduler.sync(() -> {
+
+            ServerLevel world = ((CraftPlayer) player).getHandle().level();
+            MapItemSavedData map = MapItem.getSavedData(mapId, world);
+            if (map == null) {
+                ItemStack newItem = MapItem.create(world, 0, 0, (byte) 3, false, false);
+                MapId newMapId = newItem.get(DataComponents.MAP_ID);
+                item.set(DataComponents.MAP_ID, newMapId); // Transfer the ID
+                map = MapItem.getSavedData(newMapId, world);
+            }
+
+            if (map != null) {
+                map.locked = true;
+                map.scale = 3;
+                map.trackingPosition = false;
+                map.unlimitedTracking = true;
+                map.colors = section.getPixels();
+            } else {
+                player.sendMessage("§cCannot create map. Unknown map data...");
+            }
+
+            tryPickItem(((CraftPlayer) player).getHandle().connection, item);
+        });
+    }
+
+    private static void tryPickItem(ServerGamePacketListenerImpl connection, ItemStack item) { // Access to the private method
+        invokeMethod(TRY_PICK_ITEM, connection, item);
+    }
+}

--- a/Images-v1_21_R5/src/main/java/com/andavin/images/v1_21_R5/PlayerConnectionProxy.java
+++ b/Images-v1_21_R5/src/main/java/com/andavin/images/v1_21_R5/PlayerConnectionProxy.java
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Mark
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.andavin.images.v1_21_R5;
+
+import com.andavin.images.PacketListener.ImageListener;
+import com.andavin.images.v1_21_R5.PacketListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import net.minecraft.network.protocol.game.ServerboundInteractPacket;
+import net.minecraft.network.protocol.game.ServerboundPickItemFromEntityPacket;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+
+/**
+ * @since March 19, 2023
+ * @author Andavin
+ */
+public class PlayerConnectionProxy extends ChannelInboundHandlerAdapter {
+
+    private long lastInteract;
+    private final ImageListener listener;
+    private final PacketListener packetListener;
+    private final ServerGamePacketListenerImpl connection;
+
+    PlayerConnectionProxy(ServerGamePacketListenerImpl connection,
+                          ImageListener listener, PacketListener packetListener) {
+        this.connection = connection;
+        this.listener = listener;
+        this.packetListener = packetListener;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        try {
+            if (msg instanceof ServerboundInteractPacket packet) {
+                packetListener.handle(connection.player.getBukkitEntity(), listener, packet);
+            } else if (msg instanceof ServerboundPickItemFromEntityPacket packet) {
+                long now = System.currentTimeMillis();
+                if (now - lastInteract > 10) {
+                    lastInteract = now;
+                    packetListener.handle(connection.player.getBukkitEntity(), packet);
+                }
+            }
+        } finally {
+            super.channelRead(ctx, msg);
+        }
+    }
+}

--- a/Images-v1_8_R3/pom.xml
+++ b/Images-v1_8_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_9_R2/pom.xml
+++ b/Images-v1_9_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.5</version>
+        <version>2.5.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.andavin</groupId>
     <artifactId>images-parent</artifactId>
-    <version>2.5.5</version>
+    <version>2.5.6</version>
     <modules>
         <module>Images-Core</module>
         <module>Images-Common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <module>Images-v1_21_R2</module>
         <module>Images-v1_21_R3</module>
         <module>Images-v1_21_R4</module>
+        <module>Images-v1_21_R5</module>
     </modules>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Addresses #142, caused by an NMS method renamed in v1_21_R5: `CraftPlayer.serverLevel()` → `CraftPlayer.level()`
Tested on both Spigot and Paper.

