### PR TITLE
Fix path traversal vulnerability

### DIFF
--- a/Images-Common/pom.xml
+++ b/Images-Common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-Core/pom.xml
+++ b/Images-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-Core/src/main/java/com/andavin/images/Images.java
+++ b/Images-Core/src/main/java/com/andavin/images/Images.java
@@ -341,12 +341,6 @@ public class Images extends JavaPlugin implements Listener {
      *                               image directory.
      */
     public static File getImageFile(String fileName) throws IllegalArgumentException, IllegalStateException {
-
-        File imageFile = new File(imagesDirectory, fileName);
-        if (imageFile.exists()) {
-            return imageFile;
-        }
-
         File match = null;
         File[] imageFiles = imagesDirectory.listFiles();
         checkState(imageFiles != null, "§cNo available images");

--- a/Images-v1_10_R1/pom.xml
+++ b/Images-v1_10_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_11_R1/pom.xml
+++ b/Images-v1_11_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_12_R1/pom.xml
+++ b/Images-v1_12_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_13_R2/pom.xml
+++ b/Images-v1_13_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_14_R1/pom.xml
+++ b/Images-v1_14_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_15_R1/pom.xml
+++ b/Images-v1_15_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_16_R2/pom.xml
+++ b/Images-v1_16_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_16_R3/pom.xml
+++ b/Images-v1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_17_R1/pom.xml
+++ b/Images-v1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_18_R1/pom.xml
+++ b/Images-v1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_18_R2/pom.xml
+++ b/Images-v1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R1/pom.xml
+++ b/Images-v1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R2/pom.xml
+++ b/Images-v1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_19_R3/pom.xml
+++ b/Images-v1_19_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R1/pom.xml
+++ b/Images-v1_20_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R2/pom.xml
+++ b/Images-v1_20_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R3/pom.xml
+++ b/Images-v1_20_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_20_R4/pom.xml
+++ b/Images-v1_20_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R1/pom.xml
+++ b/Images-v1_21_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R2/pom.xml
+++ b/Images-v1_21_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R3/pom.xml
+++ b/Images-v1_21_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R4/pom.xml
+++ b/Images-v1_21_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_21_R5/pom.xml
+++ b/Images-v1_21_R5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_8_R3/pom.xml
+++ b/Images-v1_8_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_9_R2/pom.xml
+++ b/Images-v1_9_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.andavin</groupId>
     <artifactId>images-parent</artifactId>
-    <version>2.5.6</version>
+    <version>2.5.7</version>
     <modules>
         <module>Images-Core</module>
         <module>Images-Common</module>


### PR DESCRIPTION
Fixes #147 

### Now it should be no longer possible to:
- Use absolute paths nor `file://`
- Use local images outside of `plugins/Images`
- Use local or loopback addresses on a URL to reach internal services

Feel free to correct me if I've missed something
