### PR TITLE
Fix issues with plugin initialization on locally built Paper jars

### DIFF
--- a/Images-Common/src/main/java/com/andavin/util/MinecraftVersion.java
+++ b/Images-Common/src/main/java/com/andavin/util/MinecraftVersion.java
@@ -193,6 +193,10 @@ public enum MinecraftVersion {
      */
     public static final MinecraftVersion CURRENT;
     private static final boolean PAPER;
+    private static final String[] PAPER_VERSION_SUFFIXES = {
+        ".build", // for incremental builds of paper
+        ".local" // for locally built jars
+    };
 
     static {
 
@@ -434,9 +438,10 @@ public enum MinecraftVersion {
         }
 
         private static String matchVersion(String version) {
-
-            if (version.endsWith(".build")) { // Paper experimental versions
-                version = version.substring(0, version.length() - ".build".length());
+            for (final String paperVersionSuffix : PAPER_VERSION_SUFFIXES) {
+                if (version.endsWith(paperVersionSuffix)) {
+                    version = version.substring(0, version.length() - paperVersionSuffix.length());
+                }
             }
 
             switch (version) {


### PR DESCRIPTION
Ran into some issues running the plugin on 26.1.x with locally built jars due to the new Paper naming scheme.

This patch simply adds another carve-out to the already established `.build` suffix by setting up an expandable string array of suffixes.

Let me know if you want any changes before merge!